### PR TITLE
Adding ability to filter template variables by timerange

### DIFF
--- a/globalnoc-tsds-datasource/src/datasource.js
+++ b/globalnoc-tsds-datasource/src/datasource.js
@@ -97,6 +97,12 @@ export class GenericDatasource {
        interpolated.target = interpolated.target.replace(/\\/g, "");
      }
 
+     // By default the dashboard's selected time range is not passed
+     // to metricFindQuery.
+     if (typeof angular !== 'undefined') {
+       interpolated.range = angular.element('grafana-app').injector().get('timeSrv').timeRange();
+     }
+
      var payload = {
        url: this.url + '/search',
        data: interpolated,

--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -174,6 +174,31 @@ def search():
 		output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Search": #Searching for template variables in Drill Down report
+
+                if "range" in inpParameter:
+                        value = inpParameter["range"]
+                        start_time = value["from"]
+                        end_time = value["to"]
+
+                        time = extract_time(start_time, end_time)
+                        start_time = time[0]
+                        end_time = time[1]
+                        time_duration = time[2]
+                        maxDataPoints = 1
+                        aggValue = int(time_duration/maxDataPoints)
+
+                        if time_duration >= 7776000:
+                                aggValue = max(aggValue, 86400)
+                        elif time_duration >= 259200:
+                                aggValue = max(aggValue, 3600)
+
+                        inpParameter["target"] = replaceQuery(
+                                inpParameter["target"],
+                                start_time,
+                                end_time,
+                                aggValue
+                        )
+
 		url = getUrl()+"query.cgi"
 		postParameters = {"method":"query","query":inpParameter["target"]}
 


### PR DESCRIPTION
By default the dashboard's selected time range is not passed to
metricFindQuery. Using the angular object we get the timerange and
pass it to tsds_grafana_handler under range. tsds_grafana_handler then
replaces all occurances of $START with range.from and $END with
range.to.