### PR TITLE
Adding support for adhoc filters

### DIFF
--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -205,14 +205,34 @@ def search():
                 output = [eachDict["name"] for eachDict in json_result["results"] if "name" in eachDict]
 
 	elif searchType == "Where": # Searching for where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
+		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100000;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
 		json_result = make_TSDS_Request(url)
 		output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Where_Related": # Searching for dependent where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
-		json_result = make_TSDS_Request(url)
-		output = [eachDict["value"] for eachDict in json_result["results"]]
+                url = ''
+
+                if not 'parent_meta_fields' in inpParameter:
+                        url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
+                else:
+                        parent_meta_field_kv_pairs = []
+                        for field in inpParameter['parent_meta_fields']:
+                                s = "{0}_like={1}".format(field['key'], field['value'])
+                                parent_meta_field_kv_pairs.append(s)
+
+                        # Becase adhoc filters do not support live
+                        # filtering (re-query as you type), limit has
+                        # been set to 10000; This should be large
+                        # enough to cover most cases.
+                        url = "{0}metadata.cgi?method=get_meta_field_values;measurement_type={1};meta_field={2};limit=10000;offset=0;{3}".format(
+                                getUrl(),
+                                inpParameter['target'],
+                                inpParameter['meta_field'],
+                                ';'.join(parent_meta_field_kv_pairs)
+                        )
+
+                json_result = make_TSDS_Request(url)
+                output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Search": #Searching for template variables in Drill Down report
 


### PR DESCRIPTION
This change adds support for adhoc filters to GenericDatasource.

When defining an adhoc template variable, the name used will be used
as the tsds measurement type; This will determine which filters are
available to the user.

When building a panel, be aware that the selected filters will be
appened to the where clause as defined in the query builder.

Also note that template variables or other adhoc filters will be used
to filter the values of subsquent adhoc filters. For example, if you
first filter on intf=et-0/0/0, only nodes with an et-0/0/0 interface
will be available under the node filter.