### PR TITLE
Adding ability to use sub function in raw query

### DIFF
--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -76,14 +76,14 @@ def findtarget_names(tsds_result, alias_list, datapoint_aliases):
                 datapoint_args = map(lambda x: x.strip(), re.split('[(,)]', key))
                 name = None
 
-                if datapoint_args[0] != 'aggregate':
-                        # If the tsds query isn't a simple aggregate
-                        # just return the datapoints name.
-                        name = key
-                elif key in datapoint_aliases and datapoint_aliases[key] != '':
+                if key in datapoint_aliases and datapoint_aliases[key] != '':
                         # Use an alias if one was defined for this
                         # datapoints' name.
                         name = datapoint_aliases[key]
+                elif datapoint_args[0] != 'aggregate':
+                        # If the tsds query isn't a simple aggregate
+                        # just return the datapoints name.
+                        name = key
                 elif 'percentile' in key:
                         _, measurement, seconds, aggregation, percentile, _, _ = datapoint_args
                         measurement = measurement.replace('values.', '')

--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -205,14 +205,34 @@ def search():
                 output = [eachDict["name"] for eachDict in json_result["results"] if "name" in eachDict]
 
 	elif searchType == "Where": # Searching for where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
+		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100000;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
 		json_result = make_TSDS_Request(url)
 		output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Where_Related": # Searching for dependent where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
-		json_result = make_TSDS_Request(url)
-		output = [eachDict["value"] for eachDict in json_result["results"]]
+                url = ''
+
+                if not 'parent_meta_fields' in inpParameter:
+                        url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
+                else:
+                        parent_meta_field_kv_pairs = []
+                        for field in inpParameter['parent_meta_fields']:
+                                s = "{0}_like={1}".format(field['key'], field['value'])
+                                parent_meta_field_kv_pairs.append(s)
+
+                        # Becase adhoc filters do not support live
+                        # filtering (re-query as you type), limit has
+                        # been set to 10000; This should be large
+                        # enough to cover most cases.
+                        url = "{0}metadata.cgi?method=get_meta_field_values;measurement_type={1};meta_field={2};limit=10000;offset=0;{3}".format(
+                                getUrl(),
+                                inpParameter['target'],
+                                inpParameter['meta_field'],
+                                ';'.join(parent_meta_field_kv_pairs)
+                        )
+
+                json_result = make_TSDS_Request(url)
+                output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Search": #Searching for template variables in Drill Down report
 


### PR DESCRIPTION
Using functions like `sum(aggregate(values.output, 300, average))` in
a raw query, would cause the python middleware to crash while building
graph labels. We now check that the top level function is aggregate;
If it's not, we generate the standard graph label based on specified
metrics.

This change also stops the middleware from crashing when no target
names are specified.

Also re-adding a default bucket size when not specified by the user.