### PR TITLE
 Limiting parent meta fields to those left of the search field

### DIFF
--- a/globalnoc-tsds-datasource/src/datasource.js
+++ b/globalnoc-tsds-datasource/src/datasource.js
@@ -69,11 +69,10 @@ export class GenericDatasource {
     return target;
   }
 
-  // getParentmetaFields returns the parent meta fields of fieldName
-  // as an array.
-  //
-  // TODO parentMetaFields should only be fields defined to the right
-  // of fieldName.
+  // getParentMetaFields returns the parent meta fields of fieldName
+  // as an array. getParentMetaFields should only return adhoc filters
+  // defined to the left of fieldName, and all other template
+  // variables.
   getParentMetaFields(fieldName) {
     var fields = [];
 
@@ -92,16 +91,17 @@ export class GenericDatasource {
       return fields;
     }
 
-    this.templateSrv.getAdhocFilters(this.name).map(function(element) {
-      if (element.key === fieldName) {
-        return;
+    var adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+    for (var i = 0; i < adhocFilters.length; i++) {
+      if (adhocFilters[i].key === fieldName) {
+        break;
       }
 
       fields.push({
-        key:   element.key,
-        value: element.value
+        key:   adhocFilters[i].key,
+        value: adhocFilters[i].value
       });
-    });
+    }
 
     return fields;
   }

--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -205,14 +205,34 @@ def search():
                 output = [eachDict["name"] for eachDict in json_result["results"] if "name" in eachDict]
 
 	elif searchType == "Where": # Searching for where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
+		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100000;offset=0;"+inpParameter['meta_field']+"_like="+inpParameter['like_field']
 		json_result = make_TSDS_Request(url)
 		output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Where_Related": # Searching for dependent where clause
-		url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=10;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
-		json_result = make_TSDS_Request(url)
-		output = [eachDict["value"] for eachDict in json_result["results"]]
+                url = ''
+
+                if not 'parent_meta_fields' in inpParameter:
+                        url = getUrl()+"metadata.cgi?method=get_meta_field_values;measurement_type="+inpParameter['target']+";meta_field="+inpParameter['meta_field']+";limit=100;offset=0;"+inpParameter['parent_meta_field']+"="+inpParameter['parent_meta_field_value']+";"+inpParameter['meta_field']+"_like="+str(inpParameter['like_field'])
+                else:
+                        parent_meta_field_kv_pairs = []
+                        for field in inpParameter['parent_meta_fields']:
+                                s = "{0}_like={1}".format(field['key'], field['value'])
+                                parent_meta_field_kv_pairs.append(s)
+
+                        # Becase adhoc filters do not support live
+                        # filtering (re-query as you type), limit has
+                        # been set to 10000; This should be large
+                        # enough to cover most cases.
+                        url = "{0}metadata.cgi?method=get_meta_field_values;measurement_type={1};meta_field={2};limit=10000;offset=0;{3}".format(
+                                getUrl(),
+                                inpParameter['target'],
+                                inpParameter['meta_field'],
+                                ';'.join(parent_meta_field_kv_pairs)
+                        )
+
+                json_result = make_TSDS_Request(url)
+                output = [eachDict["value"] for eachDict in json_result["results"]]
 
 	elif searchType == "Search": #Searching for template variables in Drill Down report
 


### PR DESCRIPTION
Parent meta fields are used to limit the results returned by
getTagValues. We now limit these to template variables and Adhoc
filters located to the left of the requested Tag. This change is for
better user experience.