### PR TITLE
Modifying effect of bucket size to act as minimum bucket size

### DIFF
--- a/globalnoc-tsds-datasource/src/partials/query.editor.html
+++ b/globalnoc-tsds-datasource/src/partials/query.editor.html
@@ -27,7 +27,7 @@
           <div ng-if="$index != 0" style="padding-left: 97px;"></div>
 
           <span class="gf-form-select-wrapper">
-            <select class="gf-form-input width-8" style="width : 100px;" name="aggregator" ng-model ="ctrl.target.aggregator[$index]" bs-tooltip="'Select an Aggregator'">
+            <select class="gf-form-input width-8" style="width : 100px;" name="aggregator" ng-model="ctrl.target.aggregator[$index]" bs-tooltip="'Select an Aggregator'">
               <option "style = background: #292929" value="average">average</option>
               <option "style = background: #292929" value="max">max</option>
               <option "style = background: #292929" value="min">min</option>
@@ -38,8 +38,8 @@
           <input type="text" ng-if="ctrl.target.aggregator[$index]=='percentile'" class="gf-form-input width-7" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
           <metric-segment-model css-class="width-10" property="ctrl.target.metricValues_array[$index]" get-options="ctrl.getMetricValues()"></metric-segment-model>
 
-          <button class="btn btn-inverse gf-form-btn query-keyword"  ng-click="ctrl.addBucket($index)" bs-tooltip="'Change bucketing size'"><i class="fa fa-bitbucket" aria-hidden="true"></i></button>
-		  <input type="text" ng-if="ctrl.target.bucket[$index]=='bucket'" class="gf-form-input max-width-5" placeholder="Bucket Size" ng-model="ctrl.target.bucketValue[$index]"/>
+          <label class="gf-form-label query-keyword width-3"><i class="fa fa-bitbucket" aria-hidden="true"></i></label>
+		  <input type="text" class="gf-form-input max-width-5" placeholder="300" ng-model="ctrl.target.bucket[$index]" bs-tooltip="'Bucket Size'"/>
 
           <label class="gf-form-label query-keyword width-3">AS</label>
 		  <input type="text" class="gf-form-input width=7" placeholder="alias" ng-model="ctrl.target.metricValueAliases[$index]"/>

--- a/globalnoc-tsds-datasource/src/query_ctrl.js
+++ b/globalnoc-tsds-datasource/src/query_ctrl.js
@@ -1,5 +1,5 @@
 import {QueryCtrl} from 'app/plugins/sdk';
-import './css/query-editor.css!'
+import './css/query-editor.css!';
 
 export class GenericDatasourceQueryCtrl extends QueryCtrl {
 
@@ -21,8 +21,7 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
     this.target.inlineGroupOperator = this.target.inlineGroupOperator||[['']];
     this.target.outerGroupOperator = this.target.outerGroupOperator || [''];
     this.target.percentileValue = this.target.percentileValue||[''];
-    this.target.bucket = this.target.bucket||[];
-    this.target.bucketValue = this.target.bucketValue||[];
+    this.target.bucket = this.target.bucket || [];
     this.target.drillDownAlias = "";
     this.index="";
     this.parentIndex="";
@@ -65,13 +64,17 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
     this.target.metricValues_array.push('Select Metric Value');
     this.target.metricValueAliases.push('');
 	this.target.aggregator.push('average');
+    this.target.bucket.push('');
 	this.target.percentileValue.push('');
   }
 
- removeValueSegment(index){
-   this.target.metricValues_array.splice(index, 1);
-   this.target.metricValueAliases.splice(index, 1);
- }
+  removeValueSegment(index){
+    this.target.metricValues_array.splice(index, 1);
+    this.target.metricValueAliases.splice(index, 1);
+    this.target.aggregator.splice(index, 1);
+    this.target.bucket.splice(index, 1);
+    this.target.percentileValue.splice(index, 1);
+  }
 
  addGroupBy(){
 		this.target.groupby_field.push('Select Column');
@@ -80,13 +83,6 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
 
  removeGroupBy(index){
 		this.target.groupby_field.splice(index,1);
-	}
-
-
-
- addBucket(index){
-		this.target.bucket.splice(index,0,'bucket');
-		this.target.bucketValue.splice(index,0,'');
 	}
 
   getColumns() {


### PR DESCRIPTION
Before if the user specified a bucket size, it would be used
regardless of the time period requested. This could result in very
expensive queries being run on tsds.

We now only use the user's value when it is larger than the
auto-scaled bucket generated by the backend.