### PR TITLE
Adding support for nested tsds methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 
 globalnoc-tsds-datasource/dist/*
+globalnoc-tsds-datasource/src/out/*

--- a/globalnoc-tsds-datasource/src/datasource.js
+++ b/globalnoc-tsds-datasource/src/datasource.js
@@ -275,7 +275,6 @@ export class GenericDatasource {
             target: this.templateSrv.replace(target, null, 'regex'),
             type:metric
         };
-        console.log(interpolated);
 
         var payload = {
             url: this.url + '/search',
@@ -397,7 +396,19 @@ export class GenericDatasource {
     }
 
     mapToTextValue(result) {
-        var a =  _.map(result.data, (d, i) => {
+        let isTestData = _.isArray(result.data) || typeof result.data.data === 'undefined';
+        let data = result.data;
+
+        if (!isTestData) {
+            if (result.data.error) {
+                console.log(result.data.error);
+                return [];
+            }
+
+            data = result.data.data;
+        }
+
+        var a =  _.map(data, (d, i) => {
             if (d && d.text && d.value) {
                 return { text: d.text, value: d.value };
             } else if (_.isObject(d)) {

--- a/globalnoc-tsds-datasource/src/datasource.js
+++ b/globalnoc-tsds-datasource/src/datasource.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import {ResponseHandler} from './response_handler'
+import {ResponseHandler} from './response_handler';
 
 export class GenericDatasource {
 
@@ -165,7 +165,7 @@ export class GenericDatasource {
                 parent_meta_fields: this.getParentMetaFields(options.key),
                 meta_field: options.key,
                 like_field: like,
-	            type: 'Where_Related'
+                type: 'Where_Related'
             },
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -215,7 +215,7 @@ export class GenericDatasource {
         var target = typeof (options) === "string" ? options : options.target;
         var interpolated = {
             target: this.templateSrv.replace(target, null, 'regex'),
-	        type:"Search"
+            type:"Search"
         };
 
         // Nested template variables are escaped, which tsds doesn't
@@ -251,7 +251,7 @@ export class GenericDatasource {
         var target = typeof (options) === "string" ? options : "Find tables";
         var interpolated = {
             target: this.templateSrv.replace(target, null, 'regex'),
-	        type: "Table"
+            type: "Table"
         };
 
         var payload = {
@@ -273,7 +273,7 @@ export class GenericDatasource {
         var target = typeof (options) === "string" ? options : options.series;
         var interpolated = {
             target: this.templateSrv.replace(target, null, 'regex'),
-	        type:metric
+            type:metric
         };
         console.log(interpolated);
 
@@ -293,28 +293,28 @@ export class GenericDatasource {
     }
 
     findWhereFields(options,parentIndex,index, like_field, callback){
-	    var target = typeof (options) === "string" ? options : options.series;
-	    if(options.whereClauseGroup[parentIndex].length >1){
-		    var whereList = options.whereClauseGroup[parentIndex];
-		    var flag = true;
-		    var meta_field = "";
-		    var parent_meta_field ="";
-		    var parent_meta_field_value="";
-		    for(var i = 0; i<whereList.length && flag; i++){
-			    if(i != index && typeof whereList[i] != 'undefined'){
-				    meta_field = whereList[index].left;
-				    parent_meta_field = whereList[i].left;
-				    parent_meta_field_value = whereList[i].right;
-				    flag = false;
-			    }
-		    }
-		    var interpolated = {
+        var target = typeof (options) === "string" ? options : options.series;
+        if(options.whereClauseGroup[parentIndex].length >1){
+            var whereList = options.whereClauseGroup[parentIndex];
+            var flag = true;
+            var meta_field = "";
+            var parent_meta_field ="";
+            var parent_meta_field_value="";
+            for(var i = 0; i<whereList.length && flag; i++){
+                if(i != index && typeof whereList[i] != 'undefined'){
+                    meta_field = whereList[index].left;
+                    parent_meta_field = whereList[i].left;
+                    parent_meta_field_value = whereList[i].right;
+                    flag = false;
+                }
+            }
+            var interpolated = {
                 target: this.templateSrv.replace(target, null, 'regex'),
                 meta_field: this.templateSrv.replace(meta_field, null, 'regex'),
                 like_field: this.templateSrv.replace(like_field, null, 'regex'),
-		        parent_meta_field: this.templateSrv.replace(parent_meta_field, null, 'regex'),
-		        parent_meta_field_value: this.templateSrv.replace(parent_meta_field_value, null, 'regex'),
-		        type:"Where_Related"
+                parent_meta_field: this.templateSrv.replace(parent_meta_field, null, 'regex'),
+                parent_meta_field_value: this.templateSrv.replace(parent_meta_field_value, null, 'regex'),
+                type:"Where_Related"
             };
 
             var payload = {
@@ -330,16 +330,16 @@ export class GenericDatasource {
                 payload.headers.Authorization = self.basicAuth;
             }
 
-	        return  this.backendSrv.datasourceRequest(payload).then(this.mapToArray).then(callback);
-	    }
-	    else {
-		    var meta_field = options.whereClauseGroup[parentIndex][index].left;
-    		var interpolated = {
-        	    target: this.templateSrv.replace(target, null, 'regex'),
-		        meta_field: this.templateSrv.replace(meta_field, null, 'regex'),
-		        like_field: this.templateSrv.replace(like_field, null, 'regex'),
-		        type:"Where"
-    		};
+            return  this.backendSrv.datasourceRequest(payload).then(this.mapToArray).then(callback);
+        }
+        else {
+            var meta_field = options.whereClauseGroup[parentIndex][index].left;
+            var interpolated = {
+                target: this.templateSrv.replace(target, null, 'regex'),
+                meta_field: this.templateSrv.replace(meta_field, null, 'regex'),
+                like_field: this.templateSrv.replace(like_field, null, 'regex'),
+                type:"Where"
+            };
 
             var payload = {
                 url: this.url + '/search',
@@ -362,13 +362,13 @@ export class GenericDatasource {
         var target = typeof (options) === "string" ? options : options.target;
         var interpolated = {
             query: this.templateSrv.replace(target, null, 'regex'),
-	        drill : options.drillDownValue,
-	        timeFrom : timeFrom,
-	        timeTo: timeTo,
-	        DB_title : DB_title,
-	        Data_source : datasource,
-	        alias: options.drillDownAlias,
-	        graph_type : type
+            drill : options.drillDownValue,
+            timeFrom : timeFrom,
+            timeTo: timeTo,
+            DB_title : DB_title,
+            Data_source : datasource,
+            alias: options.drillDownAlias,
+            graph_type : type
         };
 
         var payload = {
@@ -390,11 +390,11 @@ export class GenericDatasource {
     }
 
     findOperator(){
-	    return  new Promise(function(resolve, reject) {
-		    var a = {"data":['=','<','>'], "status":200, "statusText":"OK"};
-	        resolve(a);
-	    }).then(this.mapToTextValue);
-	}
+        return  new Promise(function(resolve, reject) {
+            var a = {"data":['=','<','>'], "status":200, "statusText":"OK"};
+            resolve(a);
+        }).then(this.mapToTextValue);
+    }
 
     mapToTextValue(result) {
         var a =  _.map(result.data, (d, i) => {
@@ -405,15 +405,15 @@ export class GenericDatasource {
             }
             return { text: d, value: d };
         });
-	    return a;
+        return a;
     }
 
     mapToArray(result){
-	    if (result.data.length == 0) {
-		    result.data = ["No results found"];
-	    }
-	    return result.data;
-	}
+        if (result.data.length == 0) {
+            result.data = ["No results found"];
+        }
+        return result.data;
+    }
 
     mapToListValue(result) {
         this.metricValue = result.data;
@@ -427,130 +427,165 @@ export class GenericDatasource {
     buildQueryParameters(options, t) {
 
       // returns template variables and its selected value i.e. {'metric':'average', 'example': 'another_metric'}
-        function getVariableDetails(){
-            let varDetails = {};
-    	    t.templateSrv.variables.forEach(function(item){
-	            varDetails[item.name] = item.current.value;
-            });
-            return varDetails;
+      function getVariableDetails(){
+        let varDetails = {};
+        t.templateSrv.variables.forEach(function(item){
+          varDetails[item.name] = item.current.value;
+        });
+        return varDetails;
+      }
+
+      function getAdhocFilters() {
+        if (typeof t.templateSrv.getAdhocFilters === 'undefined') {
+          return '';
         }
 
-        function getAdhocFilters() {
-            if (typeof t.templateSrv.getAdhocFilters === 'undefined') {
-                return '';
-            }
-
-            // [{ key: "intf", operator: "=", value: "xe-0/2/0.433" }]
-            var filters = t.templateSrv.getAdhocFilters(t.name);
-            if (filters.length === 0) {
-                return '';
-            }
-            var whereComps = filters.map(function(filter) {
-                return `${filter.key}${filter.operator}"${filter.value}"`;
-            });
-
-            return whereComps.join(' and ');
+        // [{ key: "intf", operator: "=", value: "xe-0/2/0.433" }]
+        var filters = t.templateSrv.getAdhocFilters(t.name);
+        if (filters.length === 0) {
+          return '';
         }
-
-        var scopevar = options.scopedVars;
-        // console.log("Options.targets :",options.targets);
-	    var query = _.map(options.targets, function(target) {
-            if (typeof(target) === "string") { return target; }
-		        if(target.rawQuery){
-		            var query = t.templateSrv.replace(target.target, scopevar);
-		            var oldQ = query.substr(query.indexOf("{"), query.length);
-		            var formatQ = oldQ.replace(/,/gi, " or ");
-		            query = query.replace(oldQ, formatQ);
-		            return query;
-		        } else{
-		            var query = 'get ';
-		            var seriesName = target.series;
-
-		            for(var index = 0 ; index < target.metric_array.length; index++){
-			            query+= ' '+target.metric_array[index];
-			            if ( index+1 == target.metric_array.length){
-			                break;
-			            }
-			            query+=',';
-		            }
-                    target.metricValueAliasMappings = {};
-		            for (var index=0; index < target.metricValues_array.length; index++) {
-                        var aggregation = 'aggregate(values.' + target.metricValues_array[index];
-                        aggregation += ', $quantify, ';
-			            let template_variables = getVariableDetails();
-			            if (target.aggregator[index] == "percentile") aggregation += target.aggregator[index]+'('+target.percentileValue[index]+'))';
-			            else if(target.aggregator[index] === "template") {
-
-				            let template = target.templateVariableValue[index];
-				            template = template.slice(1,template.length);
-        			        aggregation += template_variables[template]+')';
-	    		        } else aggregation += target.aggregator[index]+')';
-
-                        if (typeof target.metricValueAliases[index] === 'undefined' || target.metricValueAliases[index] === null) {
-                            target.metricValueAliases[index] = '';
-                        }
-	                    let alias_var = target.metricValueAliases[index];
-	                    let alias_key = alias_var.slice(1,alias_var.length);
-	                    if(alias_key in template_variables){
-	    	                let alias = template_variables[alias_key];
-	    	                target.metricValueAliasMappings[aggregation.toString()] = alias;
-	                    } else{
- 		                    target.metricValueAliasMappings[aggregation.toString()] = alias_var;
-	                    }
-				        query+= ', ' + aggregation;
-                    }
-			        query+= ' between ($START,$END)';
-		            if (target.groupby_field) {
-                        query += ' by ' + target.groupby_field;
-                    }
-
-        	        query += ' from ' + seriesName;
-			        query += " where ";
-			        for(var i=0; i<target.whereClauseGroup.length; i++) {
-			            if(i>0) query +=" "+ target.outerGroupOperator[i]+" ";
-				        query +=" ( ";
-				        for(var j =0 ; j<target.whereClauseGroup[i].length; j++){
-				            if(j>0) query = query +" "+target.inlineGroupOperator[i][j]+" ";
-                            query += target.whereClauseGroup[i][j].left+" "+target.whereClauseGroup[i][j].op+" \""+target.whereClauseGroup[i][j].right+"\"";
-				        }
-
-                        var adhocFilters = getAdhocFilters();
-         	            //console.log("Adhoc Filters: ",adhocFilters);
-		                if (adhocFilters === '') {
-				            query +=" )";
-                        } else {
-                            query +=" and " + adhocFilters + " )";
-                        }
-			        }
-
-		            if(target.orderby_field){
-			            query+= ' ordered by '+target.orderby_field;
-			        }
-
-                    query = t.templateSrv.replace(query, scopevar);
-                    var oldQ = query.substr(query.indexOf("{"), query.length);
-                    var formatQ = oldQ.replace(/,/gi, " or ");
-                    query = query.replace(oldQ, formatQ);
-			        target.target = query;
-			        return query;
-		        }
-	    }.bind(scopevar));
-
-        var index = 0;
-        var targets = _.map(options.targets, target => {
-
-            return {
-                target: query[index++],
-                targetAliases: target.metricValueAliasMappings,
-                targetBuckets: target.bucket,
-                refId: target.refId,
-                hide: target.hide,
-                type: target.type || 'timeserie',
-	            alias : target.target_alias
-            };
+        var whereComps = filters.map(function(filter) {
+          return `${filter.key}${filter.operator}"${filter.value}"`;
         });
 
-        options.targets = targets;
-        return options;
+        return whereComps.join(' and ');
+      }
+
+      // Builds a TSDS query string from target.func
+      function TSDSQuery(func, parentQuery) {
+        let query = '';
+        if (func.type === 'Singleton') {
+          query = `${func.title.toLowerCase()}(${parentQuery})`;
+        } else if (func.type === 'Percentile') {
+          let percentile = func.percentile || 85;
+          query = `percentile(${parentQuery}, ${percentile})`;
+        } else {
+          let bucket = func.bucket || '$quantify';
+          let method = func.method || 'average';
+          let target = func.target || 'input';
+
+          if (method == 'percentile') {
+            method = `percentile(${func.percentile})`;
+          } else if (method == 'template') {
+            let template_variables = getVariableDetails();
+            console.log(template_variables);
+            method = template_variables[func.template.replace('$', '')];
+          }
+          query = `aggregate(values.${target}, ${bucket}, ${method})`;
+        }
+
+        if (func.wrapper.length === 0) {
+          return query;
+        }
+        return TSDSQuery(func.wrapper[0], query);
+      }
+
+      var scopevar = options.scopedVars;
+      var query = _.map(options.targets, function(target) {
+
+        // Returns target when not formated as a tsds query
+        // object.
+        if (typeof(target) === "string") { return target; }
+
+        if (target.rawQuery) {
+          var query = t.templateSrv.replace(target.target, scopevar);
+          var oldQ = query.substr(query.indexOf("{"), query.length);
+          var formatQ = oldQ.replace(/,/gi, " or ");
+          query = query.replace(oldQ, formatQ);
+          return query;
+        } else {
+
+          var query = 'get ';
+          var seriesName = target.series;
+
+          for (var index = 0 ; index < target.metric_array.length; index++) {
+            query+= ' '+target.metric_array[index];
+            if (index + 1 == target.metric_array.length) {
+              break;
+            }
+            query+=',';
+          }
+          target.metricValueAliasMappings = {};
+
+          let functions = target.func.map((f) => {
+            let aggregation = TSDSQuery(f);
+
+            let start = Date.parse(options.range.from);
+            let end   = Date.parse(options.range.to);
+            let duration = (end - start) / 1000;
+
+            let defaultBucket = duration / options.maxDataPoints;
+            let size = (f.bucket === '') ? defaultBucket : parseInt(f.bucket);
+
+            if (duration >= 7776000) {
+              size = Math.max(86400, size);
+            } else if (duration >= 259200) {
+              size = Math.max(3600, size);
+            } else {
+              size = Math.max(60, size);
+            }
+
+            aggregation = aggregation.replace('$quantify', size.toString());
+            target.metricValueAliasMappings[aggregation] = f.alias;
+
+            return aggregation;
+          }).join(', ');
+
+          query += ', ' + functions;
+          query += ' between ($START,$END)';
+
+          if (target.groupby_field) {
+            query += ' by ' + target.groupby_field;
+          }
+
+          query += ' from ' + seriesName;
+          query += " where ";
+
+          for(var i=0; i<target.whereClauseGroup.length; i++) {
+            if(i>0) query +=" "+ target.outerGroupOperator[i]+" ";
+            query +=" ( ";
+            for(var j =0 ; j<target.whereClauseGroup[i].length; j++){
+              if(j>0) query = query +" "+target.inlineGroupOperator[i][j]+" ";
+              query += target.whereClauseGroup[i][j].left+" "+target.whereClauseGroup[i][j].op+" \""+target.whereClauseGroup[i][j].right+"\"";
+            }
+
+            var adhocFilters = getAdhocFilters();
+            //console.log("Adhoc Filters: ",adhocFilters);
+            if (adhocFilters === '') {
+              query +=" )";
+            } else {
+              query +=" and " + adhocFilters + " )";
+            }
+          }
+
+          if(target.orderby_field){
+            query+= ' ordered by '+target.orderby_field;
+          }
+
+          query = t.templateSrv.replace(query, scopevar);
+          var oldQ = query.substr(query.indexOf("{"), query.length);
+          var formatQ = oldQ.replace(/,/gi, " or ");
+          query = query.replace(oldQ, formatQ);
+          target.target = query;
+          return query;
+        }
+      }.bind(scopevar));
+
+      var index = 0;
+      var targets = _.map(options.targets, target => {
+        return {
+          target: query[index++],
+          targetAliases: target.metricValueAliasMappings,
+          targetBuckets: target.bucket,
+          refId: target.refId,
+          hide: target.hide,
+          type: target.type || 'timeserie',
+          alias : target.target_alias
+        };
+      });
+
+      options.targets = targets;
+      return options;
     }
 }

--- a/globalnoc-tsds-datasource/src/datasource.js
+++ b/globalnoc-tsds-datasource/src/datasource.js
@@ -33,7 +33,7 @@ export class GenericDatasource {
             data:query,
             method: 'POST',
             headers: {'Content-Type': 'application/json'}
-        }
+        };
 
         return this.post(query.targets, ops).then(function(response){
             // post resolved, check for errors in the response.

--- a/globalnoc-tsds-datasource/src/partials/query.editor.html
+++ b/globalnoc-tsds-datasource/src/partials/query.editor.html
@@ -1,12 +1,14 @@
 <query-editor-row query-ctrl="ctrl" can-collapse="false" has-text-edit-mode="true">
 
+  <!-- BEGIN - Get Template -->
   <script type="text/ng-template" id="categoryTree">
-    <div class="gf-form" ng-if="function.wrapper" ng-include="'categoryTree'" ng-init="function = function.wrapper"></div>
+
+    <div class="gf-form" ng-repeat="function in function.wrapper" ng-include="'categoryTree'"></div>
 
     <button class="btn btn-inverse gf-form-btn query-keyword" ng-click="function.addWrapper()"><i class="fa fa-plus"></i></button>
 
     <span class="gf-form-select-wrapper">
-      <select class="gf-form-input width-8" ng-model="function.title" ng-change="function.changeTitleHandler()">
+      <select class="gf-form-input width-8" ng-model="function.title" ng-change="function.changeTitle()">
         <option value="Aggregate">Aggregate</option>
         <option value="Average">Average</option>
         <option value="Count">Count</option>
@@ -49,6 +51,7 @@
     </div>
 
   </script>
+  <!-- END - Get Template -->
 
   <div ng-if="ctrl.target.rawQuery">
     <div class="gf-form">

--- a/globalnoc-tsds-datasource/src/partials/query.editor.html
+++ b/globalnoc-tsds-datasource/src/partials/query.editor.html
@@ -3,12 +3,12 @@
   <!-- BEGIN - Get Template -->
   <script type="text/ng-template" id="categoryTree">
 
-    <div class="gf-form" ng-repeat="function in function.wrapper" ng-include="'categoryTree'"></div>
+    <div class="gf-form" ng-repeat="func in func.wrapper" ng-include="'categoryTree'"></div>
 
-    <button class="btn btn-inverse gf-form-btn query-keyword" ng-click="function.addWrapper()"><i class="fa fa-plus"></i></button>
+    <button class="btn btn-inverse gf-form-btn query-keyword" ng-click="func.addWrapper()"><i class="fa fa-plus"></i></button>
 
     <span class="gf-form-select-wrapper">
-      <select class="gf-form-input width-8" ng-model="function.title" ng-change="function.changeTitle()">
+      <select class="gf-form-input width-8" ng-model="func.title" ng-change="func.changeTitle()">
         <option value="Aggregate">Aggregate</option>
         <option value="Average">Average</option>
         <option value="Count">Count</option>
@@ -16,23 +16,23 @@
         <option value="Min">Min</option>
         <option value="Percentile">Percentile</option>
         <option value="Sum">Sum</option>
-        <option value="Delete" ng-if="function.type != 'Aggregate'">Delete method</option>
+        <option value="Delete" ng-if="!func.root">-- Delete --</option>
       </select>
     </span>
 
     <!-- Singleton function -->
-    <div class="gf-form" ng-if="function.type=='Singleton'">
+    <div class="gf-form" ng-if="funct.type=='Singleton'">
     </div>
 
     <!-- Percentile function -->
-    <div class="gf-form" ng-if="function.type=='Percentile'">
-      <input type="text" class="gf-form-input width-3" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
+    <div class="gf-form" ng-if="func.type=='Percentile'">
+      <input type="text" class="gf-form-input width-3" ng-model="func.percentile"/>
     </div>
 
     <!-- Aggregate function -->
-    <div class="gf-form" ng-if="function.type=='Aggregate'">
+    <div class="gf-form" ng-if="func.type=='Aggregate'">
       <span class="gf-form-select-wrapper">
-        <select class="gf-form-input width-8" name="aggregator" ng-model="ctrl.target.aggregator[$index]" bs-tooltip="'Select an Aggregator'">
+        <select class="gf-form-input width-8" name="aggregator" ng-model="func.method" bs-tooltip="'Select an Aggregator'">
           <option "style = background: #292929" value="average">average</option>
           <option "style = background: #292929" value="max">max</option>
           <option "style = background: #292929" value="min">min</option>
@@ -41,13 +41,13 @@
         </select>
       </span>
 
-      <input type="text" ng-if="ctrl.target.aggregator[$index]=='percentile'" class="gf-form-input width-7" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
-      <input type="text" ng-if="ctrl.target.aggregator[$index]=='template'" class="gf-form-input width-21" placeholder="$<variable_name>" ng-model="ctrl.target.templateVariableValue[$index]"/>
+      <input type="text" ng-if="func.method=='percentile'" class="gf-form-input width-7" ng-model="func.percentile"/>
+      <input type="text" ng-if="func.method=='template'" class="gf-form-input width-10" placeholder="$<variable_name>" ng-model="func.template"/>
 
-      <metric-segment-model css-class="width-10" property="ctrl.target.metricValues_array[$index]" get-options="ctrl.getMetricValues()"></metric-segment-model>
+      <metric-segment-model css-class="width-10" property="func.target" ng-model="func.target" get-options="ctrl.getMetricValues()"></metric-segment-model>
 
       <label class="gf-form-label query-keyword width-3"><i class="fa fa-bitbucket" aria-hidden="true"></i></label>
-      <input type="text" class="gf-form-input width-5" placeholder="300" ng-model="ctrl.target.bucket[$index]" bs-tooltip="'Bucket Size'"/>
+      <input type="text" class="gf-form-input width-5" placeholder="300" ng-model="func.bucket" bs-tooltip="'Bucket Size'"/>
     </div>
 
   </script>
@@ -79,10 +79,10 @@
           <label ng-if="$index == 0" class="gf-form-label query-keyword width-7">GET</label>
           <div ng-if="$index != 0" style="padding-left: 97px;"></div>
 
-          <div class="gf-form" ng-include="'categoryTree'" ng-init="function = ctrl.target.function[$index]"></div>
+          <div class="gf-form" ng-include="'categoryTree'" ng-init="func = ctrl.target.func[$index]"></div>
 
           <label class="gf-form-label query-keyword width-3">AS</label>
-	      <input type="text" class="gf-form-input width=7" placeholder="alias" ng-model="ctrl.target.metricValueAliases[$index]"/>
+	      <input type="text" class="gf-form-input width=7" placeholder="alias" ng-model="ctrl.target.func[$index].alias"/>
 
           <button class="btn btn-inverse gf-form-btn" ng-click="ctrl.removeValueSegment($index)"><i class="fa fa-trash"></i></button>
         </div>

--- a/globalnoc-tsds-datasource/src/partials/query.editor.html
+++ b/globalnoc-tsds-datasource/src/partials/query.editor.html
@@ -9,13 +9,13 @@
 
     <span class="gf-form-select-wrapper">
       <select class="gf-form-input width-8" ng-model="func.title" ng-change="func.changeTitle()">
-        <option value="Aggregate">Aggregate</option>
-        <option value="Average">Average</option>
-        <option value="Count">Count</option>
-        <option value="Max">Max</option>
-        <option value="Min">Min</option>
-        <option value="Percentile">Percentile</option>
-        <option value="Sum">Sum</option>
+        <option value="Aggregate" ng-if="func.root">Aggregate</option>
+        <option value="Average" ng-if="!func.root">Average</option>
+        <option value="Count" ng-if="!func.root">Count</option>
+        <option value="Max" ng-if="!func.root">Max</option>
+        <option value="Min" ng-if="!func.root">Min</option>
+        <option value="Percentile" ng-if="!func.root">Percentile</option>
+        <option value="Sum" ng-if="!func.root">Sum</option>
         <option value="Delete" ng-if="!func.root">-- Delete --</option>
       </select>
     </span>

--- a/globalnoc-tsds-datasource/src/partials/query.editor.html
+++ b/globalnoc-tsds-datasource/src/partials/query.editor.html
@@ -1,5 +1,55 @@
 <query-editor-row query-ctrl="ctrl" can-collapse="false" has-text-edit-mode="true">
 
+  <script type="text/ng-template" id="categoryTree">
+    <div class="gf-form" ng-if="function.wrapper" ng-include="'categoryTree'" ng-init="function = function.wrapper"></div>
+
+    <button class="btn btn-inverse gf-form-btn query-keyword" ng-click="function.addWrapper()"><i class="fa fa-plus"></i></button>
+
+    <span class="gf-form-select-wrapper">
+      <select class="gf-form-input width-8" ng-model="function.title" ng-change="function.changeTitleHandler()">
+        <option value="Aggregate">Aggregate</option>
+        <option value="Average">Average</option>
+        <option value="Count">Count</option>
+        <option value="Max">Max</option>
+        <option value="Min">Min</option>
+        <option value="Percentile">Percentile</option>
+        <option value="Sum">Sum</option>
+        <option value="Delete" ng-if="function.type != 'Aggregate'">Delete method</option>
+      </select>
+    </span>
+
+    <!-- Singleton function -->
+    <div class="gf-form" ng-if="function.type=='Singleton'">
+    </div>
+
+    <!-- Percentile function -->
+    <div class="gf-form" ng-if="function.type=='Percentile'">
+      <input type="text" class="gf-form-input width-3" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
+    </div>
+
+    <!-- Aggregate function -->
+    <div class="gf-form" ng-if="function.type=='Aggregate'">
+      <span class="gf-form-select-wrapper">
+        <select class="gf-form-input width-8" name="aggregator" ng-model="ctrl.target.aggregator[$index]" bs-tooltip="'Select an Aggregator'">
+          <option "style = background: #292929" value="average">average</option>
+          <option "style = background: #292929" value="max">max</option>
+          <option "style = background: #292929" value="min">min</option>
+          <option "style = background: #292929" value="percentile">percentile</option>
+          <option "style = background: #292929" value="template">template</option>
+        </select>
+      </span>
+
+      <input type="text" ng-if="ctrl.target.aggregator[$index]=='percentile'" class="gf-form-input width-7" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
+      <input type="text" ng-if="ctrl.target.aggregator[$index]=='template'" class="gf-form-input width-21" placeholder="$<variable_name>" ng-model="ctrl.target.templateVariableValue[$index]"/>
+
+      <metric-segment-model css-class="width-10" property="ctrl.target.metricValues_array[$index]" get-options="ctrl.getMetricValues()"></metric-segment-model>
+
+      <label class="gf-form-label query-keyword width-3"><i class="fa fa-bitbucket" aria-hidden="true"></i></label>
+      <input type="text" class="gf-form-input width-5" placeholder="300" ng-model="ctrl.target.bucket[$index]" bs-tooltip="'Bucket Size'"/>
+    </div>
+
+  </script>
+
   <div ng-if="ctrl.target.rawQuery">
     <div class="gf-form">
       <input type="text" class="gf-form-input" ng-model="ctrl.target.target" spellcheck="false" ng-blur="ctrl.onChangeInternal()"></input>
@@ -26,32 +76,18 @@
           <label ng-if="$index == 0" class="gf-form-label query-keyword width-7">GET</label>
           <div ng-if="$index != 0" style="padding-left: 97px;"></div>
 
-          <span class="gf-form-select-wrapper">
-            <select class="gf-form-input width-8" style="width : 100px;" name="aggregator" ng-model="ctrl.target.aggregator[$index]" bs-tooltip="'Select an Aggregator'">
-              <option "style = background: #292929" value="average">average</option>
-              <option "style = background: #292929" value="max">max</option>
-              <option "style = background: #292929" value="min">min</option>
-              <option "style = background: #292929" value="percentile">percentile</option>
-	      <option "style = background: #292929" value="template">template</option>
-            </select>
-          </span>
-
-	  <input type="text" ng-if="ctrl.target.aggregator[$index]=='template'" class="gf-form-input width-21" placeholder="$<variable_name>" ng-model="ctrl.target.templateVariableValue[$index]"/>
-
-          <input type="text" ng-if="ctrl.target.aggregator[$index]=='percentile'" class="gf-form-input width-7" placeholder="85" ng-model="ctrl.target.percentileValue[$index]"/>
-          <metric-segment-model css-class="width-10" property="ctrl.target.metricValues_array[$index]" get-options="ctrl.getMetricValues()"></metric-segment-model>
-
-          <label class="gf-form-label query-keyword width-3"><i class="fa fa-bitbucket" aria-hidden="true"></i></label>
-		  <input type="text" class="gf-form-input max-width-5" placeholder="300" ng-model="ctrl.target.bucket[$index]" bs-tooltip="'Bucket Size'"/>
+          <div class="gf-form" ng-include="'categoryTree'" ng-init="function = ctrl.target.function[$index]"></div>
 
           <label class="gf-form-label query-keyword width-3">AS</label>
-		  <input type="text" class="gf-form-input width=7" placeholder="alias" ng-model="ctrl.target.metricValueAliases[$index]"/>
+	      <input type="text" class="gf-form-input width=7" placeholder="alias" ng-model="ctrl.target.metricValueAliases[$index]"/>
 
-          <button class = "btn btn-inverse gf-form-btn"  ng-click="ctrl.removeValueSegment($index)"><i class="fa fa-trash"></i></button>
+          <button class="btn btn-inverse gf-form-btn" ng-click="ctrl.removeValueSegment($index)"><i class="fa fa-trash"></i></button>
         </div>
+
         <div class="gf-form">
-          <button class = "btn btn-inverse gf-form-btn query-keyword"  ng-click="ctrl.addValueSegments()"><i class="fa fa-plus"></i></button>
+          <button class="btn btn-inverse gf-form-btn query-keyword" ng-click="ctrl.addValueSegments()"><i class="fa fa-plus"></i></button>
         </div>
+
 	    <div class="gf-form gf-form--grow">
           <div class="gf-form-label gf-form-label--grow"></div>
         </div>
@@ -62,20 +98,18 @@
 	  <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">get metric</label>
 	  </div>
-      <div ng-repeat = "element in ctrl.target.metric_array track by $index" class="gf-form">
+      <div ng-repeat="element in ctrl.target.metric_array track by $index" class="gf-form">
 		<metric-segment-model property="ctrl.target.metric_array[$index]" get-options = "ctrl.getColumns()"></metric-segment-model>
-		<button  class = "btn btn-inverse gf-form-btn"  ng-click="ctrl.removeSegment($index)"><i class="fa fa-trash"></i></button>
+		<button class="btn btn-inverse gf-form-btn"  ng-click="ctrl.removeSegment($index)"><i class="fa fa-trash"></i></button>
       </div>
 	  
 	  <div class="gf-form">
         <button class = "btn btn-inverse gf-form-btn query-keyword"  ng-click="ctrl.addSegments()"><i class="fa fa-plus"></i></button>
       </div>
 
-
 	  <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>
-	  
 	</div>
 	
 

--- a/globalnoc-tsds-datasource/src/query_ctrl.js
+++ b/globalnoc-tsds-datasource/src/query_ctrl.js
@@ -120,14 +120,11 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
     this.target.metric_array = this.target.metric_array||['Select Metric'];
     this.target.metricValues_array = this.target.metricValues_array || ['Select Metric Value'];
     this.target.metricValueAliases = this.target.metricValueAliases || [''];
-    this.target.aggregator = this.target.aggregator ||['average'];
     this.target.target_alias = this.target.target_alias||"";
     this.target.whereClauseGroup = this.target.whereClauseGroup||[[{'left':'Select Metric','op':'','right':''}]];
     this.target.inlineGroupOperator = this.target.inlineGroupOperator||[['']];
     this.target.outerGroupOperator = this.target.outerGroupOperator || [''];
-    this.target.percentileValue = this.target.percentileValue||[''];
     this.target.templateVariableValue = this.target.templateVariableValue || [''];   
-    this.target.bucket = this.target.bucket || [];
 
     // Creates an array of GenericFunctions from existing data, or if
     // the data doesn't exist, setups a single GenericFunction.
@@ -177,9 +174,6 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
   addValueSegments(){
     this.target.metricValues_array.push('Select Metric Value');
     this.target.metricValueAliases.push('');
-	this.target.aggregator.push('average');
-    this.target.bucket.push('');
-	this.target.percentileValue.push('');
 
     this.target.func.push(new GenericFunction('Aggregate', 'Aggregate', [], {root: true}));
   }
@@ -187,9 +181,6 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
   removeValueSegment(index){
     this.target.metricValues_array.splice(index, 1);
     this.target.metricValueAliases.splice(index, 1);
-    this.target.aggregator.splice(index, 1);
-    this.target.bucket.splice(index, 1);
-    this.target.percentileValue.splice(index, 1);
 
     this.target.func.splice(index, 1);
   }

--- a/globalnoc-tsds-datasource/src/query_ctrl.js
+++ b/globalnoc-tsds-datasource/src/query_ctrl.js
@@ -1,6 +1,69 @@
 import {QueryCtrl} from 'app/plugins/sdk';
 import './css/query-editor.css!';
 
+
+class GenericFunction {
+  constructor(type, title) {
+    this.type = type;
+    this.title = title;
+    this.wrapper = undefined;
+
+    this.onClickDelete = undefined;
+
+    this.addWrapper = this.addWrapper.bind(this);
+    this.delWrapper = this.delWrapper.bind(this);
+    this.clickDeleteHandler = this.clickDeleteHandler.bind(this);
+  }
+
+  addWrapper() {
+    this.wrapper = new GenericFunction('Singleton', 'Average');
+    this.wrapper.onClickDelete = this.delWrapper.bind(this);
+
+    console.log(this);
+  }
+
+  delWrapper(f) {
+    delete(this.wrapper);
+
+    let func = f;
+
+    if (typeof func.wrapper !== 'undefined') {
+      this.wrapper = func.wrapper;
+      this.wrapper.onClickDelete = this.delWrapper.bind(this);
+    }
+
+    // console.log('Removed wrapper ' + f.title + ' from ' + this.title + '. Linked now to ' + this.wrapper.title);
+    console.log(this);
+  }
+
+  clickDeleteHandler(e) {
+    if (typeof this.onClickDelete !== 'undefined') {
+      this.onClickDelete(this);
+    }
+  }
+
+  changeTitleHandler() {
+    if (this.title === 'Average') {
+      this.type = 'Singleton';
+    } else if (this.title === 'Count') {
+      this.type = 'Singleton';
+    } else if (this.title === 'Percentile') {
+      this.type = 'Percentile';
+    } else if (this.title === 'Sum') {
+      this.type = 'Singleton';
+    } else if (this.title === 'Max') {
+      this.type = 'Singleton';
+    } else if (this.title === 'Min') {
+      this.type = 'Singleton';
+    } else if (this.title === 'Aggregate') {
+      this.type = 'Aggregate';
+    } else {
+      // Remove this function
+      this.clickDeleteHandler();
+    }
+  }
+}
+
 export class GenericDatasourceQueryCtrl extends QueryCtrl {
 
   constructor($scope, $injector, uiSegmentSrv)  {
@@ -24,6 +87,9 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
     this.target.percentileValue = this.target.percentileValue||[''];
     this.target.templateVariableValue = this.target.templateVariableValue || [''];   
     this.target.bucket = this.target.bucket || [];
+
+    this.target.function = this.target.function || [new GenericFunction('Aggregate', 'Aggregate')];
+
     this.target.drillDownAlias = "";
     this.index="";
     this.parentIndex="";

--- a/globalnoc-tsds-datasource/src/query_ctrl.js
+++ b/globalnoc-tsds-datasource/src/query_ctrl.js
@@ -61,6 +61,26 @@ class GenericFunction {
       this.whenDeleteSelected(this);
     }
   }
+
+  tsdsQuery(parentQuery) {
+    let query = '';
+    if (this.type === 'Singleton') {
+      query = `${this.title}(${parentQuery})`;
+    } else if (this.type === 'Percentile') {
+      let percentile = this.percentile || 85;
+      query = `percentile(${percentile}, ${parentQuery})`;
+    } else {
+      let bucket = this.bucket || 300;
+      let method = this.method || 'average';
+      let target = this.target || 'input';
+      query = `aggregate(values.${target}, ${method}, ${bucket})`;
+    }
+
+    if (this.wrapper.length === 0) {
+      return query;
+    }
+    return this.wrapper[0].tsdsQuery(query);
+  }
 }
 
 export class GenericDatasourceQueryCtrl extends QueryCtrl {
@@ -90,7 +110,7 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
     // Creates an array of GenericFunctions from existing data, or if
     // the data doesn't exist, setups a single GenericFunction.
     this.target.function = this.target.function.map((f) => new GenericFunction(f.type, f.title, f.wrapper)) || [new GenericFunction('Aggregate', 'Aggregate')];
-    console.log(this.target.function);
+    console.log(this.target.function[0].tsdsQuery(''));
 
     this.target.drillDownAlias = "";
     this.index="";

--- a/tsds-grafana-handler/tsds_grafana_handler.py
+++ b/tsds-grafana-handler/tsds_grafana_handler.py
@@ -265,8 +265,8 @@ def make_TSDS_Request(url,postParam = None):
         except Exception as e:
 		print 'Status: 412 Precondition Failed'
 		print
-        print json.dumps({"error":e, "data": None}, default=serialize)
-        exit(0)
+                print json.dumps({"error":e, "data": None}, default=serialize)
+                exit(0)
 
 def testDataSource():
 	url = tsds_url+"query.cgi"


### PR DESCRIPTION
This change adds a button to the left of each target query. This button creates a wrapper function around the target query (Usually something like min or max).

Logically the change removes the `aggregator`, `percentileValue`, and `bucket` from `GenericDatasourceQueryCtrl`; These function parameters are now stored in `GenericFunction`.