### PR TITLE
Fixing sub-string replacement for extrapolation functions

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -134,19 +134,12 @@ class GenericDatasource {
                 // key of 'extrapolate(..., Date(1526705726))'; This
                 // breaks our alias mappings. Ensure the key from TSDS
                 // no longer includes the Date method.
-                let newval = null;
-                let newkey = null;
-
                 for (let key in result) {
                   if (key.indexOf('extrapolate') !== -1) {
-                    newval = result[key];
-                    newkey = key.replace(/Date\(\d+\)/g, function(x) {
+                    let newkey = key.replace(/Date\(\d+\)/g, function(x) {
                       return x.match(/\d+/);
                     });
-                  }
-
-                  if (newval !== null) {
-                    result[newkey] = newval;
+                    result[newkey] = result[key];
                     delete result[key];
                   }
                 }


### PR DESCRIPTION
When extrapolate functions are detected string manipulation must be
employed to ensure that the result key matches the original request
key. An implemenation bug in this replacement caused all keys
following the extrapolate key to be removed. This caused aggregate
functions to occasionally be disregarded.